### PR TITLE
Remove pooled config from config.json creation

### DIFF
--- a/docs/app.md
+++ b/docs/app.md
@@ -154,11 +154,7 @@ The *config.json* file contains the configration for application.  It is used to
 	{
 	  "loglevel": "INFO",
 	  "actionRunner": {
-	    "type": "pooled",
-	    "pooled": {
-	      "numWorkers": 5,
-	      "workQueueSize": 50,
-	    }
+	    "type": "pooled"
 	  },
 	  "services": [
 	    {

--- a/flogo/config.go
+++ b/flogo/config.go
@@ -128,7 +128,7 @@ func DefaultEngineConfig() *EngineConfig {
 	var ec EngineConfig
 
 	ec.LogLevel = "INFO"
-	ec.RunnerConfig = &RunnerConfig{Type: "pooled", Pooled: &PooledConfig{NumWorkers: 5, WorkQueueSize: 50}}
+	ec.RunnerConfig = &RunnerConfig{Type: "pooled"}
 	ec.Services = make([]*ServiceConfig, 0)
 
 	ec.Services = append(ec.Services, &ServiceConfig{Name: "stateRecorder", Enabled: false, Settings: map[string]string{"host": "", "port": ""}})

--- a/flogo/create.go
+++ b/flogo/create.go
@@ -26,7 +26,7 @@ func init() {
 }
 
 type cmdCreate struct {
-	option *cli.OptionInfo
+	option     *cli.OptionInfo
 	libVersion string
 }
 

--- a/flogo/files.go
+++ b/flogo/files.go
@@ -119,7 +119,7 @@ type ConfigInfo struct {
 func createEngineConfigGoFile(codeSourcePath string, configInfo *ConfigInfo) {
 
 	if configInfo == nil {
-		configInfo = &ConfigInfo{Include:false, ConfigJSON:"", TriggerJSON:""}
+		configInfo = &ConfigInfo{Include: false, ConfigJSON: "", TriggerJSON: ""}
 	}
 
 	f, _ := os.Create(path(codeSourcePath, fileConfigGo))
@@ -253,7 +253,6 @@ func createExprsGoFile(codeSourcePath string, flows map[string]map[int]string) {
 	fgutil.RenderTemplate(f, tplExprsGoFile, flows)
 	f.Close()
 }
-
 
 var tplExprsGoFile = `package main
 


### PR DESCRIPTION
No default PooledConfig object is created, since the engine now gives us the default values.

Tested creating a new app and running it without the values in config.json