### PR TITLE
Shim

### DIFF
--- a/app/build.go
+++ b/app/build.go
@@ -10,15 +10,15 @@ import (
 
 var optBuild = &cli.OptionInfo{
 	Name:      "build",
-	UsageLine: "build [-o][-i][-bp]",
+	UsageLine: "build [-o][-e][-sp][-shim]",
 	Short:     "build the flogo application",
 	Long: `Build the flogo application.
 
 Options:
-    -o   optimize for directly referenced contributions
-    -e   embed application configuration into executable
-    -sp  skip prepare
-    -ep  trigger entrypoint
+    -o    optimize for directly referenced contributions
+    -e    embed application configuration into executable
+    -sp   skip prepare
+    -shim trigger shim
 `,
 }
 
@@ -31,7 +31,7 @@ type cmdBuild struct {
 	optimize    bool
 	skipPrepare bool
 	embedConfig bool
-	entrypoint  string
+	shim        string
 }
 
 // HasOptionInfo implementation of cli.HasOptionInfo.OptionInfo
@@ -44,7 +44,7 @@ func (c *cmdBuild) AddFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&(c.optimize), "o", false, "optimize build")
 	fs.BoolVar(&(c.embedConfig), "e", false, "embed config")
 	fs.BoolVar(&(c.skipPrepare), "sp", false, "skip prepare")
-	fs.StringVar(&(c.entrypoint), "ep", "", "entrypoint")
+	fs.StringVar(&(c.shim), "shim", "", "trigger shim")
 }
 
 // Exec implementation of cli.Command.Exec
@@ -57,6 +57,6 @@ func (c *cmdBuild) Exec(args []string) error {
 		os.Exit(2)
 	}
 
-	options := &BuildOptions{SkipPrepare:c.skipPrepare, PrepareOptions:&PrepareOptions{OptimizeImports:c.optimize, EmbedConfig:c.embedConfig, Entrypoint: c.entrypoint}}
+	options := &BuildOptions{SkipPrepare:c.skipPrepare, PrepareOptions:&PrepareOptions{OptimizeImports:c.optimize, EmbedConfig:c.embedConfig, Shim: c.shim}}
 	return BuildApp(SetupExistingProjectEnv(appDir), options)
 }

--- a/app/build.go
+++ b/app/build.go
@@ -18,6 +18,7 @@ Options:
     -o   optimize for directly referenced contributions
     -e   embed application configuration into executable
     -sp  skip prepare
+    -ep  trigger entrypoint
 `,
 }
 
@@ -30,6 +31,7 @@ type cmdBuild struct {
 	optimize    bool
 	skipPrepare bool
 	embedConfig bool
+	entrypoint  string
 }
 
 // HasOptionInfo implementation of cli.HasOptionInfo.OptionInfo
@@ -42,6 +44,7 @@ func (c *cmdBuild) AddFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&(c.optimize), "o", false, "optimize build")
 	fs.BoolVar(&(c.embedConfig), "e", false, "embed config")
 	fs.BoolVar(&(c.skipPrepare), "sp", false, "skip prepare")
+	fs.StringVar(&(c.entrypoint), "ep", "", "entrypoint")
 }
 
 // Exec implementation of cli.Command.Exec
@@ -54,6 +57,6 @@ func (c *cmdBuild) Exec(args []string) error {
 		os.Exit(2)
 	}
 
-	options := &BuildOptions{SkipPrepare:c.skipPrepare, PrepareOptions:&PrepareOptions{OptimizeImports:c.optimize, EmbedConfig:c.embedConfig}}
+	options := &BuildOptions{SkipPrepare:c.skipPrepare, PrepareOptions:&PrepareOptions{OptimizeImports:c.optimize, EmbedConfig:c.embedConfig, Entrypoint: c.entrypoint}}
 	return BuildApp(SetupExistingProjectEnv(appDir), options)
 }

--- a/app/config.go
+++ b/app/config.go
@@ -57,6 +57,12 @@ type TriggerDescriptor struct {
 	Ref string `json:"ref"`
 }
 
+type TriggerMetadata struct {
+	Name       string `json:"name"`
+	Ref        string `json:"ref"`
+	Entrypoint string `json:"entrypoint"`
+}
+
 // todo make make ActionDescriptor generic
 // ActionDescriptor is the config descriptor for an Action
 type ActionDescriptor struct {
@@ -133,7 +139,7 @@ func ExtractDependencies(descriptor *FlogoAppDescriptor) []*Dependency {
 	dh := &depHolder{}
 
 	for _, action := range descriptor.Actions {
-		dh.deps = append(dh.deps, &Dependency{ContribType:ACTION, Ref:action.Ref})
+		dh.deps = append(dh.deps, &Dependency{ContribType: ACTION, Ref: action.Ref})
 
 		if action.Data != nil && action.Data.Flow != nil {
 			extractDepsFromTask(action.Data.Flow.RootTask, dh)
@@ -145,7 +151,7 @@ func ExtractDependencies(descriptor *FlogoAppDescriptor) []*Dependency {
 	}
 
 	for _, trigger := range descriptor.Triggers {
-		dh.deps = append(dh.deps,&Dependency{ContribType:TRIGGER, Ref:trigger.Ref})
+		dh.deps = append(dh.deps, &Dependency{ContribType: TRIGGER, Ref: trigger.Ref})
 	}
 
 	return dh.deps
@@ -155,7 +161,7 @@ func ExtractDependencies(descriptor *FlogoAppDescriptor) []*Dependency {
 func extractDepsFromTask(task *Task, dh *depHolder) {
 
 	if task.Ref != "" {
-		dh.deps = append(dh.deps, &Dependency{ContribType:ACTIVITY, Ref:task.Ref})
+		dh.deps = append(dh.deps, &Dependency{ContribType: ACTIVITY, Ref: task.Ref})
 	}
 
 	for _, childTask := range task.Tasks {

--- a/app/config.go
+++ b/app/config.go
@@ -58,9 +58,9 @@ type TriggerDescriptor struct {
 }
 
 type TriggerMetadata struct {
-	Name       string `json:"name"`
-	Ref        string `json:"ref"`
-	Entrypoint string `json:"entrypoint"`
+	Name string `json:"name"`
+	Ref  string `json:"ref"`
+	Shim string `json:"shim"`
 }
 
 // todo make make ActionDescriptor generic

--- a/app/files.go
+++ b/app/files.go
@@ -225,18 +225,23 @@ var tplEntrypointGoFile = `// Do not change this file, it has been generated usi
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 
 	"github.com/TIBCOSoftware/flogo-lib/app"
+	"github.com/TIBCOSoftware/flogo-lib/config"
 	"github.com/TIBCOSoftware/flogo-lib/engine"
-	"encoding/json"
+	"github.com/TIBCOSoftware/flogo-lib/logger"
+
 )
 
 // embedded flogo app descriptor file
 const flogoJSON string = ` + "`{{.FlogoJSON}}`" + `
 
 func init() {
+	config.SetDefaultLogLevel("ERROR")
+	logger.SetLogLevel(logger.ErrorLevel)
 
 	var cp app.ConfigProvider
 

--- a/app/files.go
+++ b/app/files.go
@@ -12,11 +12,12 @@ const (
 	fileMainGo        string = "main.go"
 	fileImportsGo     string = "imports.go"
 	fileEmbeddedAppGo string = "embeddedapp.go"
-	fileEntrypointGo  string = "entrypoint.go"
+	fileShimGo        string = "shim.go"
+	fileShimSupportGo string = "shim_support.go"
 
+	dirShim      string = "shim"
 	pathFlogoLib string = "github.com/TIBCOSoftware/flogo-lib"
 )
-
 
 func createMainGoFile(codeSourcePath string, flogoJSON string) {
 
@@ -158,7 +159,6 @@ func removeEmbeddedAppGoFile(codeSourcePath string) {
 	os.Remove(path.Join(codeSourcePath, fileEmbeddedAppGo))
 }
 
-
 var tplEmbeddedAppGoFile = `// Do not change this file, it has been generated using flogo-cli
 // If you change it and rebuild the application your changes might get lost
 package main
@@ -197,7 +197,7 @@ func (d *embeddedProvider) GetApp() (*app.Config, error){
 }
 `
 
-func createEntrypointGoFile(codeSourcePath string, flogoJSON string, embeddedConfig bool) {
+func createShimSupportGoFile(codeSourcePath string, flogoJSON string, embeddedConfig bool) {
 
 	configJson := ""
 
@@ -211,16 +211,17 @@ func createEntrypointGoFile(codeSourcePath string, flogoJSON string, embeddedCon
 		configJson,
 	}
 
-	f, _ := os.Create(path.Join(codeSourcePath, fileEntrypointGo))
-	fgutil.RenderTemplate(f, tplEntrypointGoFile, &data)
+	f, _ := os.Create(path.Join(codeSourcePath, fileShimSupportGo))
+	fgutil.RenderTemplate(f, tplShimSupportGoFile, &data)
 	f.Close()
 }
 
-func removeEntrypointGoFile(codeSourcePath string) {
-	os.Remove(path.Join(codeSourcePath, fileEntrypointGo))
+func removeShimGoFiles(codeSourcePath string) {
+	os.Remove(path.Join(codeSourcePath, fileShimGo))
+	os.Remove(path.Join(codeSourcePath, fileShimSupportGo))
 }
 
-var tplEntrypointGoFile = `// Do not change this file, it has been generated using flogo-cli
+var tplShimSupportGoFile = `// Do not change this file, it has been generated using flogo-cli
 // If you change it and rebuild the application your changes might get lost
 package main
 

--- a/env/gb.go
+++ b/env/gb.go
@@ -165,7 +165,11 @@ func (e *GbProject) InstallDependency(depPath string, version string) error {
 	}
 
 	if version == "" {
-		cmd = exec.Command("gb", "vendor", "fetch", "-branch", "entrypoint", depPath)
+		if strings.HasPrefix(depPath,"github.com/TIBCOSoftware/flogo-") {
+			cmd = exec.Command("gb", "vendor", "fetch", "-branch", "entrypoint", depPath)
+		} else {
+			cmd = exec.Command("gb", "vendor", "fetch", depPath)
+		}
 	} else {
 		var tag string
 

--- a/env/gb.go
+++ b/env/gb.go
@@ -165,7 +165,7 @@ func (e *GbProject) InstallDependency(depPath string, version string) error {
 	}
 
 	if version == "" {
-		cmd = exec.Command("gb", "vendor", "fetch", depPath)
+		cmd = exec.Command("gb", "vendor", "fetch", "-branch", "entrypoint", depPath)
 	} else {
 		var tag string
 

--- a/env/gb.go
+++ b/env/gb.go
@@ -165,11 +165,11 @@ func (e *GbProject) InstallDependency(depPath string, version string) error {
 	}
 
 	if version == "" {
-		if strings.HasPrefix(depPath,"github.com/TIBCOSoftware/flogo-") {
-			cmd = exec.Command("gb", "vendor", "fetch", "-branch", "entrypoint", depPath)
-		} else {
-			cmd = exec.Command("gb", "vendor", "fetch", depPath)
-		}
+		//if strings.HasPrefix(depPath,"github.com/TIBCOSoftware/flogo-") {
+		//	cmd = exec.Command("gb", "vendor", "fetch", "-branch", "entrypoint", depPath)
+		//} else {
+		cmd = exec.Command("gb", "vendor", "fetch", depPath)
+		//}
 	} else {
 		var tag string
 


### PR DESCRIPTION
Add "shim" support to triggers.  A trigger with a shim is one that can bypass the regular engine hosting and control how it is invoked.  Directly through its own main or as a plugin.

When an app has a trigger with a shim, that shim can be specified to be used in the build step using the trigger id of the trigger with the shim:

```flogo build -shim <triggerId>```

Shims can be set on a trigger by adding "shim":"main" (specifies its own main) or "shim":"plugin" (indicating that the shim entrypoint is via a go plugin).  The trigger should also contain a "shim" directory with its necessary support file.  

```
	shim/shim.go   <-- for plugin or main
	shim/Makefile  <-- if plugin type, for now looks for "Makefile" that will be invoked at build time
```
