### PR TITLE
added restore dependency from a manifest

### DIFF
--- a/app/api.go
+++ b/app/api.go
@@ -9,9 +9,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	"os/exec"
+
 	"github.com/TIBCOSoftware/flogo-cli/env"
 	"github.com/TIBCOSoftware/flogo-cli/util"
-	"os/exec"
 )
 
 // BuildPreProcessor interface for build pre-processors
@@ -66,18 +67,23 @@ func CreateApp(env env.Project, appJson string, appDir string, appName string, v
 	if err != nil {
 		return err
 	}
+	//if manifest exists in the parent folder, use it to set up the dependecies
+	err = env.RestoreDependency()
+	var deps []*Dependency
+	//if restore didn't occur, install dependencies
+	if err != nil {
 
-	//todo allow ability to specify flogo-lib version
-	env.InstallDependency(pathFlogoLib, "")
+		//todo allow ability to specify flogo-lib version
+		env.InstallDependency("github.com/TIBCOSoftware/flogo-lib", "")
 
-	deps := ExtractDependencies(descriptor)
+		deps := ExtractDependencies(descriptor)
 
-	for _, dep := range deps {
-		path, version := splitVersion(dep.Ref)
-		err = env.InstallDependency(path, version)
-		if err != nil {
-			return err
+		for _, dep := range deps {
+			path, version := splitVersion(dep.Ref)
+			err = env.InstallDependency(path, version)
 		}
+	} else {
+		fmt.Println("Dependencies are restored.")
 	}
 
 	// create source files

--- a/env/env.go
+++ b/env/env.go
@@ -32,6 +32,9 @@ type Project interface {
 	// Uninstall a go dependency
 	UninstallDependency(path string) error
 
+	// Restore go dependencies
+	RestoreDependency() error
+
 	// Build the project
 	Build() error
 }


### PR DESCRIPTION
Fixes issue #69. If there is a manifest in the current working directory, flogo-cli's 'create' command uses the manifest to restored the project's vendor folder. Thus, supporting the versioning of the libraries for a flogo project. Otherwise, it keeps the current behavior. 