### PR TITLE
Update to docker template

### DIFF
--- a/app/api.go
+++ b/app/api.go
@@ -21,6 +21,7 @@ import (
 const dockerfile = `# Dockerfile for {{.name}}
 # VERSION {{.version}}
 FROM alpine
+RUN apk update && apk add ca-certificates
 ADD {{.name}}-linux-amd64 .
 EXPOSE {{.port}}
 CMD ./{{.name}}-linux-amd64`


### PR DESCRIPTION
Added a line to the docker template in `app/api.go` (`RUN apk update && apk add ca-certificates`) so the app can both host and invoke HTTPs based services without having the certificates folder from the host mounted as a volume