### PR TITLE
Dep: fixing GOBIN issue

### DIFF
--- a/env/project.go
+++ b/env/project.go
@@ -163,6 +163,7 @@ func (e *FlogoProject) Build() error {
 	cmd.Dir = e.GetAppDir()
 	newEnv := os.Environ()
 	newEnv = append(newEnv, fmt.Sprintf("GOPATH=%s", e.GetRootDir()))
+	newEnv = append(newEnv, "GOBIN=\"\"")
 	if e.GetDockerBuild() {
         fmt.Println("Setting GOOS to linux because this is a docker build")
         newEnv = append(newEnv, "GOOS=linux")

--- a/env/project.go
+++ b/env/project.go
@@ -167,7 +167,7 @@ func (e *FlogoProject) Build() error {
 	if e.GetDockerBuild() {
         fmt.Println("Setting GOOS to linux because this is a docker build")
         newEnv = append(newEnv, "GOOS=linux")
-     }
+     }	
 	cmd.Env = newEnv
 
 	cmd.Stdout = os.Stdout

--- a/env/project.go
+++ b/env/project.go
@@ -163,7 +163,7 @@ func (e *FlogoProject) Build() error {
 	cmd.Dir = e.GetAppDir()
 	newEnv := os.Environ()
 	newEnv = append(newEnv, fmt.Sprintf("GOPATH=%s", e.GetRootDir()))
-	newEnv = append(newEnv, "GOBIN=\"\"")
+	newEnv = append(newEnv, fmt.Sprintf("GOBIN=%s/bin", e.GetRootDir()))
 	if e.GetDockerBuild() {
         fmt.Println("Setting GOOS to linux because this is a docker build")
         newEnv = append(newEnv, "GOOS=linux")


### PR DESCRIPTION
Because go install is used, if GOBIN is specified, the compiled binary will be placed in $GOBIN not ./bin