### PR TITLE
Regenerate the metadata after shim ensure

### DIFF
--- a/app/api.go
+++ b/app/api.go
@@ -232,6 +232,13 @@ func doPrepare(env env.Project, options *PrepareOptions) (err error) {
 					
 					// ensure deps after the shim.go has been copied to main.go...
 					depManager.Ensure()
+					
+					// This is a bit of a workaround, will resolve with a better solution in the future
+					// generate metadata again... ensure will remove it
+					err = generateGoMetadata(env)
+					if err != nil {
+						return err
+					}					
 
 					if metadata.Shim == "plugin" {
 						//look for Makefile and execute it


### PR DESCRIPTION
After ensure is run, the generated metadata is removed, regenerate to resolve issue TIBCOSoftware/flogo#191