### PR TITLE
Allow for a new type of shim called gobuild

### DIFF
--- a/app/files.go
+++ b/app/files.go
@@ -12,7 +12,7 @@ const (
 	fileMainGo        string = "main.go"
 	fileEmbeddedAppGo string = "embeddedapp.go"
 	makeFile          string = "Makefile"
-	gobuildFile       string = "gobuild.go"
+	gobuildFile       string = "build.go"
 	fileShimGo        string = "shim.go"
 	fileShimSupportGo string = "shim_support.go"
 

--- a/app/files.go
+++ b/app/files.go
@@ -12,6 +12,7 @@ const (
 	fileMainGo        string = "main.go"
 	fileEmbeddedAppGo string = "embeddedapp.go"
 	makeFile          string = "Makefile"
+	gobuildFile       string = "gobuild.go"
 	fileShimGo        string = "shim.go"
 	fileShimSupportGo string = "shim_support.go"
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[X] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**What is the current behavior?** The current triggers require external dependencies to be able to build (like `make` for the Lambda trigger). This requires the developer to install additional software (which may or may not be available for his operating system)

**What is the new behavior?** With this PR we can introduce the ability to have each trigger specify their own build steps using a gobuild.go file. So trigger developers can write their build steps using a `go` file and assuming the trigger shim is set to `gobuild` in the `activity.json` the `flogo build -shim <id>` command will execute the new build file. This removes the need to install additional software like Make

**Have you tested this?** I've tested the new behavior on Windows 10 and Ubuntu 18.04, creating Flogo apps deployed to Lambda.

_Note_
I've made the changes additive so that existing triggers that use the shim options (like Lambda and CLI) are not broken and developers can continue to use their existing workflow. 
