### PR TITLE
Print proper error if trigger doesn't exist

### DIFF
--- a/app/api.go
+++ b/app/api.go
@@ -211,10 +211,11 @@ func doPrepare(env env.Project, options *PrepareOptions) (err error) {
 
 		fmt.Println("Shim:", options.Shim)
 
-		for _, value := range descriptor.Triggers {
+		found := false
 
-			fmt.Println("Id:", value.Id)
+		for _, value := range descriptor.Triggers {
 			if value.Id == options.Shim {
+				found = true
 				triggerPath := filepath.Join(env.GetVendorSrcDir(), value.Ref, "trigger.json")
 
 				mdJson, err := fgutil.LoadLocalFile(triggerPath)
@@ -289,6 +290,12 @@ func doPrepare(env env.Project, options *PrepareOptions) (err error) {
 
 				break
 			}
+		}
+
+		if !found {
+			fmt.Printf("\nCan't locate trigger with id [%s] in flogo.json\n", options.Shim)
+			fmt.Printf("Please check if you have specified the correct trigger id\n\n")
+			os.Exit(2)
 		}
 
 	} else if options.EmbedConfig {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: https://github.com/TIBCOSoftware/flogo/issues/286

**What is the current behavior?**

If the trigger id passed in doesn't exist an error is thrown 
```
runtime.main_main·f: relocation target main.main not defined
runtime.main_main·f: undefined: "main.main"
FATAL: command "build" failed: exit status 2
```

**What is the new behavior?**

If the trigger id passed in doesn't exist a friendly error is shown
```
$ flogo build -e -shim my_lambda_trigger
Shim: my_lambda_trigger

Can't locate trigger with id [my_lambda_trigger] in flogo.json
Please check if you have specified the correct trigger id
```
