### PR TITLE
Remove error message in 'flogo version' command when there is no project in current directory

### DIFF
--- a/app/util.go
+++ b/app/util.go
@@ -23,20 +23,33 @@ func SetupNewProjectEnv() env.Project {
 }
 
 func SetupExistingProjectEnv(rootDir string) env.Project {
+	proj, _ := SetupExistingProjectEnvWithOrWithoutExitOnFailure(rootDir, true)
+	return proj
+}
+
+func SetupExistingProjectEnvWithOrWithoutExitOnFailure(rootDir string, exitOnFailure bool) (env.Project, error) {
 
 	proj := env.NewFlogoProject()
 
 	if err := proj.Init(rootDir); err != nil {
-		fmt.Fprintf(os.Stderr, "Error initializing flogo app project: %s\n\n", err.Error())
-		os.Exit(2)
+		if exitOnFailure {
+			fmt.Fprintf(os.Stderr, "Error initializing flogo app project: %s\n\n", err.Error())
+			os.Exit(2)
+		} else {
+			return nil, err
+		}
 	}
 
 	if err := proj.Open(); err != nil {
-		fmt.Fprintf(os.Stderr, "Error opening flogo app project: %s\n\n", err.Error())
-		os.Exit(2)
+		if exitOnFailure {
+			fmt.Fprintf(os.Stderr, "Error opening flogo app project: %s\n\n", err.Error())
+			os.Exit(2)
+		} else {
+			return nil, err
+		}
 	}
 
-	return proj
+	return proj, nil
 }
 
 func splitVersion(t string) (path string, version string) {

--- a/app/version.go
+++ b/app/version.go
@@ -97,27 +97,29 @@ func (c *cmdVersion) Exec(args []string) error {
 		os.Exit(2)
 	}
 
-	project := SetupExistingProjectEnv(appDir)
+	project, _ := SetupExistingProjectEnvWithOrWithoutExitOnFailure(appDir, false)
 
-	config, err := toml.LoadFile(filepath.Join(project.GetAppDir(), lockName))
+	if project != nil {
+		config, err := toml.LoadFile(filepath.Join(project.GetAppDir(), lockName))
 
-	if err != nil {
-		fmt.Println("Error ", err.Error())
-	} else {
-		raw := rawLock{}
-		err := config.Unmarshal(&raw)
 		if err != nil {
-			fmt.Printf("Unable to parse the lock as TOML")
-		}
+			fmt.Println("Error ", err.Error())
+		} else {
+			raw := rawLock{}
+			err := config.Unmarshal(&raw)
+			if err != nil {
+				fmt.Printf("Unable to parse the lock as TOML")
+			}
 
-		for _, v := range raw.Projects {
-			if caseInsensitiveContains(v.Name, "flogo") {
-				if v.Version == "" {
-					line = fmt.Sprintf("Your project uses %s branch %s and revision %s\n", v.Name, v.Branch, v.Revision)
-				} else {
-					line = fmt.Sprintf("Your project uses %s version %s\n", v.Name, v.Version)
+			for _, v := range raw.Projects {
+				if caseInsensitiveContains(v.Name, "flogo") {
+					if v.Version == "" {
+						line = fmt.Sprintf("Your project uses %s branch %s and revision %s\n", v.Name, v.Branch, v.Revision)
+					} else {
+						line = fmt.Sprintf("Your project uses %s version %s\n", v.Name, v.Version)
+					}
+					fmt.Fprint(os.Stdout, line)
 				}
-				fmt.Fprint(os.Stdout, line)
 			}
 		}
 	}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: 

When the command ```flogo version``` is used in a directory with no Flogo project (i.e. no *flogo.json* file), there is an error message displayed saying it is not possible to open the project.

This error message is annoying and misleading for users. When installing a CLI tool, the first thing done is often to execute it with *--version* or *version* parameter to check whether everything is running fine.

**What is the current behavior?**

The command ```flogo version``` in a directory with no Flogo project (i.e. no *flogo.json* file) outputs:

```
flogo cli version [v0.5.6-2-g867ad50]
Error opening flogo app project: Invalid project, source directory doesn't exists
```


**What is the new behavior?**

The command ```flogo version``` in a directory with no Flogo project (i.e. no *flogo.json* file) outputs:

```
flogo cli version [v0.5.6-3-gf43e112]
```

The command ```flogo version``` in a directory with a Flogo project (i.e. no *flogo.json* file) output remains unchanged:

```
flogo cli version [v0.5.6-3-gf43e112]
Your project uses github.com/TIBCOSoftware/flogo-contrib version v0.5.6
Your project uses github.com/TIBCOSoftware/flogo-lib version v0.5.6
```