### PR TITLE
Better help on the CLI (#2)

### DIFF
--- a/app/create.go
+++ b/app/create.go
@@ -62,13 +62,13 @@ func (c *cmdCreate) Exec(args []string) error {
 			appJson, err = fgutil.LoadRemoteFile(c.fileName)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error: Error loading app file '%s' - %s\n\n", c.fileName, err.Error())
-				os.Exit(2)
+				cmdUsage(c)
 			}
 		} else {
 			appJson, err = fgutil.LoadLocalFile(c.fileName)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error: Error loading app file '%s' - %s\n\n", c.fileName, err.Error())
-				os.Exit(2)
+				cmdUsage(c)
 			}
 
 			if len(args) != 0 {

--- a/app/util.go
+++ b/app/util.go
@@ -101,7 +101,8 @@ func Usage() {
 }
 
 func cmdUsage(command cli.Command) {
-	cli.CmdUsage("", command)
+	cli.PrintCmdHelp("", command)
+	os.Exit(2)
 }
 
 func printUsage(w io.Writer) {


### PR DESCRIPTION

**What kind of change does this PR introduce?** (check one with "x")
```
[x Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #72 

**What is the current behavior?**

When entering a cmd with an incorrect syntax we should display the correct syntax again. For example the following cmd:

flogo create -f SampleApp2 ~/Downloads/SampleApp.json

Simply yields the following error. 

**What is the new behavior?**

The correct syntax should be displayed again after the error.

Error: Error loading app file 'SampleApp2' - open SampleApp2: no such file or directory


I changed also the details of the command usage to have all the options.

Example

```
$ flogo create -f example.json app

Error: Error loading app file 'example.json' - open example.json: no such file or directory

Usage:

    flogo  create AppName

Creates a flogo project.

Options:
    -flv     specify the flogo dependency constraints as comma separated value (for example github.com/TIBCOSoftware/flogo-lib@0.0.0,github.com/TIBCOSoftware/flogo-contrib@0.0.0)
    -f       specify the flogo.json to create project from
    -vendor  specify existing vendor directory to copy
```