### PR TITLE
remove duplicates in imports.go generated by 'flogo create'

### DIFF
--- a/app/files.go
+++ b/app/files.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/TIBCOSoftware/flogo-cli/config"
-	"github.com/TIBCOSoftware/flogo-cli/util"
+	fgutil "github.com/TIBCOSoftware/flogo-cli/util"
 )
 
 const (
@@ -152,7 +152,17 @@ func createImportsGoFile(codeSourcePath string, deps []*config.Dependency) error
 		return err
 	}
 
-	fgutil.RenderTemplate(f, tplNewImportsGoFile, deps)
+	// dedup:
+	depMap := make(map[string]*config.Dependency)
+	var uniqueDeps []*config.Dependency
+	for _, dep := range deps {
+		if _, ok := depMap[dep.Ref]; !ok {
+			depMap[dep.Ref] = dep
+			uniqueDeps = append(uniqueDeps, dep)
+		}
+	}
+
+	fgutil.RenderTemplate(f, tplNewImportsGoFile, uniqueDeps)
 	f.Close()
 
 	return nil


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
imports.go generated by 'flogo create' contains many duplicated lines of same package

**What is the new behavior?**
This fix will generate a cleaner imports.go that includes each unique package only once.